### PR TITLE
Added GitHub Copilot Bicep blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Hand-picked tips and tricks to help you learn Azure Bicep and get you ready to s
 - [Project Bicep: ARM Templates Re-Imagined](https://samcogan.com/project-bicep-arm-templates-re-imagined/)
 - [Run PowerShell scripts with Azure Bicep](https://johnlokerse.dev/2022/12/04/run-powershell-scripts-with-azure-bicep/)
 - [Simplifying Azure IaC with Azure Bicep child resources](https://thecloudmarathoner.com/index.php/2022/03/01/simplifying-azure-iac-with-azure-bicep-child-resources/)
+- [Three use cases for using GitHub Copilot with Azure Bicep](https://johnlokerse.dev/2023/02/27/three-use-cases-for-using-github-copilot-with-azure-bicep/)
 - [What are the good options to manage sensitive info in Azure Bicep?](https://thecloudmarathoner.com/index.php/2021/11/16/managing-azure-bicep-sensitive-info-with-key-vault/)
 - [What is new in Azure Bicep v0.4?](https://thecloudmarathoner.com/index.php/2021/09/02/how-to-check-and-update-azure-cli-verison-on-your-workstation/)
 - [Whitelisting your Public IP with Azure Bicep and PowerShell](https://luke.geek.nz/azure/whitelisting-your-public-ip-with-azure-bicep/)


### PR DESCRIPTION
Added my latest blog "Three use cases for using GitHub Copilot with Azure Bicep". 

@ElYusubov I don't know if I used the correct category and if it's a good addition to the repository because of the focus on Bicep **and** GitHub Copilot.