### PR TITLE
Add AzureNamer to Community Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Hand-picked tips and tricks to help you learn Azure Bicep and get you ready to s
 - [AzAdvertizer](https://www.azadvertizer.net/)
 - [Az-bootstrap - helps to set up Azure and GitHub environments for IaC projects](https://github.com/kewalaka/az-bootstrap)
 - [Azure Resource Name Generator PowerShell Module - Bicep files generation](https://github.com/mimachniak/AzureResources-NameGenerator)
+- [AzureNamer - web tool to generate CAF compliant Azure resource names and export Bicep](https://azurenamingconventions.com/)
 - [Azure Databricks Bicep Local Deploy extension](https://github.com/Gijsreyn/bicep-ext-databricks)
 - [Azure DevOps Bicep Local Deploy extension](https://github.com/johnlokerse/azure-devops-bicep-local-deploy)
 - [Bicep Local Extension - Password Generator](https://github.com/mimachniak/bicep-ext-PassWordGenerator)


### PR DESCRIPTION
Adds AzureNamer under Community Tools.

It is a free, no-login web tool that generates CAF compliant Azure resource names for 200+ resource types with live length and character validation, and exports them as Bicep (also Terraform, JSON, CSV). It complements the existing PowerShell name generator entry with a browser-based option, no install needed.

Single-line addition, no other changes.